### PR TITLE
More options to modify times in walker_settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,4 +44,10 @@ The `?` will be replaced with the correct quest reset time. Depending on your wa
 10 00:00-?
 ```
 
-There's another wildcard, `+X`. This will be replaced with the reset time + X hours. So if the reset time is `08:00`, `?-+2` would be replaced with `08:00-10:00`
+There are two more wildcards, `+X` and `+X:Y`. `+X:Y` will be replaced with the reset time + X hours and Y minutes. `+X` is equivalent to `+X:00`. So if the reset time is `08:00`, `?-+2` and `?-+2:00` would each be replaced with `08:00-10:00`.
+
+There is no subtraction of time. Instead, you could for example use `+22:30` to get the time 90 minutes before the reset time.
+
+Additionally there are `min` and `max` functions. `min(a,b)` is replaced by the earlier of the two times `a` and `b`, `max(a,b)` by the later one. These functions can also be nested.
+
+Example: `min(?,7:30)-max(+4:15,10:00)` will be replaced by `07:30-12:15` for a reset time of `08:00`.

--- a/autoevents.py
+++ b/autoevents.py
@@ -109,7 +109,7 @@ class EventWatcher(mapadroid.utils.pluginBase.Plugin):
                     quests_walkers = f.read()
                 self.__quests_walkers = {}
                 for line in quests_walkers.strip("\n").split("\n"):
-                    splits = line.split(" ")
+                    splits = line.split(" ", 1)
                     self.__quests_walkers[splits[0]] = splits[1]
             except FileNotFoundError:
                 self.__quests_walkers = {}


### PR DESCRIPTION
Changes:
- Allow some whitespace in walker_settings.txt: `min(xx:xx, yy:yy)` is allowed, `+ xx:xx` or `xx : xx` is not.
- Allow walker values `xx:xx` in addition to `xx:xx-yy:yy`
- Ensure hours and minutes always have leading zero if less than 10
- When using `+X`, allow X to have more than one digit.
- New wildcard `+X:Y` to add hours and minutes
- Addition of times uses modulo. `08:00 + 17:00 => 01:00` instead of `25:00`
- `min` and `max` functions. `min(a, b)` returns the earlier of the two times, `max` the later one. These functions can be nested, limited only by the python recursion depth.
- Added explanation and examples of new features.

Names of functions and variables are up for debate.

This PR has been tested using the following script on Windows 10 using python 3.6:
```
import re


def process(timestring, final_time):
    final_hour, final_minute = final_time.split(":")

    def process_part(part: str):
        # replace this with lines 191 - 233 from autoevents.py
        return final_time

    return '-'.join(map(process_part, timestring.split('-')))


if __name__ == '__main__':
    # list of tuples of ?, timestring, expected time_for_area
    testdata = [
        ("08:00", "01:23-14:56", "01:23-14:56"),
        ("08:00", "01:23", "01:23"),
        ("08:00", "?-14:56", "08:00-14:56"),
        ("08:00", "01:23-?", "01:23-08:00"),
        ("08:00", "?", "08:00"),
        ("08:12", "+2-+17", "10:12-01:12"),
        ("08:35", "+2:12-+17:45", "10:47-02:20"),
        ("08:35", "min(7:12, ?)-max(7:12, ?)", "07:12-08:35"),
        ("8:35", "min(10:00  ,  max( +22:01, 7:0)) - min(10:00,max(+1:2,7:00))", "07:00-09:37"),
    ]
    for f, ts, ta in testdata:
        actual = process(ts, f)
        assert ta == actual, f"Expected {ta}, got {actual}"
    print("Tests successful")
```

It runs fine on my MAD instance (RPi, python 3.7).