### PR TITLE
add conditional wildcard

### DIFF
--- a/autoevents.py
+++ b/autoevents.py
@@ -198,6 +198,13 @@ class EventWatcher(mapadroid.utils.pluginBase.Plugin):
                     add_hour = int(add_hour[0])
                     added_time = str(int(final_hour) + add_hour).zfill(2) + ":" + final_minute
                     new_timepart = re.sub(r"\+\d", new_timepart, added_time)
+                if "|" in new_timepart:
+                    add_hour = re.findall(r"\|(\d)", new_timepart)
+                    add_hour = int(add_hour[0])
+                    if final_time != self.__quests_default_time:
+                        add_hour = 0
+                    added_time = str(int(final_hour) + add_hour).zfill(2) + ":" + final_minute
+                    new_timepart = re.sub(r"\|\d", new_timepart, added_time)
                 new_times.append(new_timepart)
             time_for_area = "-".join(new_times)
 


### PR DESCRIPTION
This commit adds another wildcard by using the "|" operator followed by a number. It acts like the "+X" wildcard but only if the quest reset time is equal to the quest default time. So the +X only gets applied when no event is happening on that day, on event days its the same time as "?".
Therefore it can be used to disable an area inside a walker when an event changes the quest reset time. 
You can use it to disable a big quest area that you would scan over the night but don't want to scan during the day because it would take too long after an event started at like 10 AM and only scan a small area on the event start date.

example walker_settings.txt:
**161 ?-|5** (big quest area, only scans at night)
**162 ?-+2** (small quest area, scans up to 2h after an event start)
**163 +1-?** (normal mon walker)
**164 +1-?** (normal mon walker)