### PR TITLE
Season event workaround

### DIFF
--- a/autoevents.py
+++ b/autoevents.py
@@ -79,6 +79,7 @@ class EventWatcher(mapadroid.utils.pluginBase.Plugin):
             self.tz_offset = datetime.now().hour - datetime.utcnow().hour
             self.__sleep = self._pluginconfig.getint("plugin", "sleep", fallback=3600)
             self.__delete_events = self._pluginconfig.getboolean("plugin", "delete_events", fallback=False)
+            self.__ignore_events_duration_in_days = self._pluginconfig.getint("plugin", "ignore_events_duration_in_days", fallback=999)
 
             if "Quest Resets" in self._pluginconfig.sections():
                 self.__quests_enable = self._pluginconfig.getboolean("Quest Resets", "enable", fallback=False)
@@ -366,6 +367,10 @@ class EventWatcher(mapadroid.utils.pluginBase.Plugin):
             if start is None or end is None:
                 continue
             if end < datetime.now():
+                continue
+            # season workaround: ignore events with long duration
+            if (end - start) > timedelta(days=self.__ignore_events_duration_in_days):
+                self._mad['logger'].info(f'Event Watcher: Ignore following event because duration exceed configurated limit of {self.__ignore_events_duration_in_days} days: {raw_event["name"]}')
                 continue
             event_dict = {
                 "start": start,

--- a/autoevents.py
+++ b/autoevents.py
@@ -79,7 +79,7 @@ class EventWatcher(mapadroid.utils.pluginBase.Plugin):
             self.tz_offset = datetime.now().hour - datetime.utcnow().hour
             self.__sleep = self._pluginconfig.getint("plugin", "sleep", fallback=3600)
             self.__delete_events = self._pluginconfig.getboolean("plugin", "delete_events", fallback=False)
-            self.__ignore_events_duration_in_days = self._pluginconfig.getint("plugin", "ignore_events_duration_in_days", fallback=999)
+            self.__ignore_events_duration_in_days = self._pluginconfig.getint("plugin", "max_event_duration", fallback=999)
 
             if "Quest Resets" in self._pluginconfig.sections():
                 self.__quests_enable = self._pluginconfig.getboolean("Quest Resets", "enable", fallback=False)

--- a/plugin.ini.example
+++ b/plugin.ini.example
@@ -2,7 +2,8 @@
 active = true
 sleep = 3600
 delete_events = false
-ignore_events_duration_in_days = 30
+; ignore events with duration longer than max_event_duration days
+max_event_duration = 30
 
 [Quest Resets]
 enable = true

--- a/plugin.ini.example
+++ b/plugin.ini.example
@@ -2,6 +2,7 @@
 active = true
 sleep = 3600
 delete_events = false
+ignore_events_duration_in_days = 30
 
 [Quest Resets]
 enable = true


### PR DESCRIPTION
Add new plugin.ini parameter `ignore_events_duration_in_days=x` to ignore events > x days. Can be used to ignore season events. I used this workaround since a few weeks with `ignore_events_duration_in_days=30` without any issue.