### PR TITLE
Feature: pokemon and quest reset on event change

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Both can be used alone or in parallel.
   - Available event types are `event`, `community-day`, `spotlight-hour` and `raid-hour`. The last 2 are less relevant. Most events are of type `event`.
 
 ### Config options (plugin.ini) - Quest reset
-- `enable_reschedule`: Whether or not to enable auto Quest reset by SQL TRUNCATE trs_quest table of MAD database
+- `enable_reset`: Whether or not to enable auto Quest reset by SQL TRUNCATE trs_quest table of MAD database
 - `reset_for`: Define event types, which triggers quest resets for their start, end or both. see `reschedule_for` for details.
 
 ### walker_settings.txt

--- a/README.md
+++ b/README.md
@@ -19,9 +19,11 @@ If this is the first time you're setting up a MAD Plugin:
 - go to MAD/plugins/EventWatcher/ and `cp plugin.ini.example plugin.ini && cp walker_settings.txt.example walker_settings.txt`
 - Restart MAD
 
-There's two config options:
+There are following config options:
 - `sleep` to define the time to wait in-between checking for new events. By default it's one hour.
 - `delete_events` if you want Event Watcher to delete non-needed events (including basically all you've created yourself) - by default it's set to False.
+- `max_event_duration` ignore events with duration longer than max_event_duration days. Set to 999 if you want to care also for session events
+- `reset_pokemons` option to automatically delete obsolete pokemon from MAD database on start and end of spawn event to enable MAD to rescan pokemon. true: enable function, false: disable function (default)
 
 please also join [this discord](https://discord.gg/cMZs5tk)
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ If this is the first time you're setting up a MAD Plugin:
 # Config
 
 ## Config options (plugin.ini) - General
+In section `[plugin]`:
 - `sleep` to define the time to wait in-between checking for new events. By default it's one hour.
 - `delete_events` if you want Event Watcher to delete non-needed MAD spawn events (including basically all you've created yourself) - by default it's set to False.
 - `max_event_duration` ignore events with duration longer than max_event_duration days. Set to 999 if you want to care also for session events
@@ -35,25 +36,27 @@ If this is the first time you're setting up a MAD Plugin:
 
 ## Feature: Quest Resets
 There are two different methods to adapt quest scans:
-1. **Quest reschedule**: automatically adjust Quest scan times based on on-going events and then changes your walkerarea values. See chapter "Config options - Quest reschedule" and "walker_settings.txt"
-2. **Quest reset**: delete all quests from MAD DB on quest related event changes. See chapter "Config options - Quest reset"
+1. **Quest reset**: automatically adjust Quest scan times based on on-going events and then changes your walkerarea values. See chapter "Config options - Quest reschedule" and "walker_settings.txt"
+2. **Quest delete**: delete all quests from MAD DB on quest related event changes. See chapter "Config options - Quest reset"
 
 Both can be used alone or in parallel.
 
-### Config options (plugin.ini) - Quest reschedule 
-- `enable_reschedule`: Whether or not to enable auto Quest reschedules
-- `reschedule_default_time`: The time you want Quest scans to start on normal days
-- `reschedule_max_time`: Ignore event changes that are later than this for Quest reschedules
-- `reschedule_check_timeframe`: Defines the hours in which the plugin checks for quest reschedules
-- `reschedule_for`: Define event types, which triggers quest reschedules for their start, end or both.
+### Config options (plugin.ini) - Quest reset
+In section `[Quest Resets]`:
+- `enable`: Whether or not to enable auto Quest reset (reschedule of quest scan).
+- `default_time`: The time you want Quest scans to start on normal days.
+- `max_time`: Ignore event changes that are later than this for Quest reset.
+- `check_timeframe`: Defines the hours in which the plugin checks for quest reset.
+- `reset_for`: Define event types, which triggers quest reset for their start, end or both.
   - `event community-day` - if you want to rescan quests for every start and end of an event and cday
   - `event:start` - only rescan quests for event starts (my personal recommendation)
   - `community-day event:end` - Rescan quests for cday starts and ends, but only for event ends
   - Available event types are `event`, `community-day`, `spotlight-hour` and `raid-hour`. The last 2 are less relevant. Most events are of type `event`.
 
-### Config options (plugin.ini) - Quest reset
-- `enable_reset`: Whether or not to enable auto Quest reset by SQL TRUNCATE trs_quest table of MAD database
-- `reset_for`: Define event types, which triggers quest resets for their start, end or both. see `reschedule_for` for details.
+### Config options (plugin.ini) - Quest delete
+In section `[Quest Resets]`:
+- `enable_quest_delete`: Whether or not to enable auto Quest delete by SQL TRUNCATE trs_quest table of MAD database.
+- `quest_delete_for`: Define event types, which triggers quest delete for their start, end or both. see `reset_for` for details.
 
 ### walker_settings.txt
 ```

--- a/README.md
+++ b/README.md
@@ -1,52 +1,59 @@
-## Development
+# Development
 
 As @ccev stepped back from further developing a number of his tools, I @crhbetz decided to take over on eventwatcher for now. I'll try my best to keep existing functionality in a working state. On the `asyncio` branch there's a version aiming at being fully compatible with MADs switch to asyncio that's currently being finished.
-
 Feedback and contributions (PRs) are very welcome.
 
-### Improvements
+## Improvements
 
 Possible improvements that I've thought of
 - Better documentation. I think a lot of people don't understand what Event Watcher does or how it should be configured
 - Possibly an optional Raid Boss prediction. Instead of writing an egg to the DB, it could write the current boss to it. I tried implementing this but it got super hacky. maybe there's a better solution than what I had.
 
-## Usage:
+# How does it work?
+To not put unnecessary load on cool community-made websites, the Plugin pulls data from [this file](https://github.com/ccev/pogoinfo/blob/v2/active/events.json). A list I automatically update and commit to github.
+
+The Plugin then grabs that file and checks if an event is missing for you or changed information and then updates your database accordingly.
+
+# Install:
 You can import this like any other MAD Plugin.
 
 If this is the first time you're setting up a MAD Plugin:
 - Download Eventwatcher.mp on the [releases page](https://github.com/ccev/mp-eventwatcher/releases)
 - Open {madmin.com}/plugins, click "Choose file" and choose the EventWatcher.mp file you just downloaded. Or drag&drop it there.
 - go to MAD/plugins/EventWatcher/ and `cp plugin.ini.example plugin.ini && cp walker_settings.txt.example walker_settings.txt`
+- configurate plugin by edit plugin.ini and walker_settings.txt (see "Config" chapter)
 - Restart MAD
 
-There are following config options:
+# Config
+
+## Config options (plugin.ini) - General
 - `sleep` to define the time to wait in-between checking for new events. By default it's one hour.
-- `delete_events` if you want Event Watcher to delete non-needed events (including basically all you've created yourself) - by default it's set to False.
+- `delete_events` if you want Event Watcher to delete non-needed MAD spawn events (including basically all you've created yourself) - by default it's set to False.
 - `max_event_duration` ignore events with duration longer than max_event_duration days. Set to 999 if you want to care also for session events
 - `reset_pokemons` option to automatically delete obsolete pokemon from MAD database on start and end of spawn event to enable MAD to rescan pokemon. true: enable function, false: disable function (default)
 - `reset_pokemons_truncate` option to use TRUNCATE SQL query instead of DELETE. Recommended for bigger instances. true: use TRUNCATE, false: use DELETE (default)
 
-please also join [this discord](https://discord.gg/cMZs5tk)
+## Feature: Quest Resets
+There are two different methods to adapt quest scans:
+1. **Quest reschedule**: automatically adjust Quest scan times based on on-going events and then changes your walkerarea values. See chapter "Config options - Quest reschedule" and "walker_settings.txt"
+2. **Quest reset**: delete all quests from MAD DB on quest related event changes. See chapter "Config options - Quest reset"
 
-## How does it work?
-To not put unnecessary load on cool community-made websites, the Plugin pulls data from [this file](https://github.com/ccev/pogoinfo/blob/v2/active/events.json). A list I automatically update and commit to github.
+Both can be used alone or in parallel.
 
-The Plugin then grabs that file and checks if an event is missing for you or changed information and then updates your database accordingly.
-
-## Quest Resets
-Event Watcher can automatically adjust Quest scan times based on on-going events. It does it by checking the file above for events that reset Quests and then changes your walkerarea values with the event times.
-
-### Config options
-- **enable**: Whether or not to enable auto Quest resets
-default_time: The time you want Quest scans to start on normal days
-- **max_time**: Ignore reset times that are later than this
-- **check_timeframe**: Defines the hours in which the plugin checks quest resets
-- **reset_for**: Define event types and if you want quests to reset for their start, end or both.
+### Config options (plugin.ini) - Quest reschedule 
+- `enable_reschedule`: Whether or not to enable auto Quest reschedules
+- `reschedule_default_time`: The time you want Quest scans to start on normal days
+- `reschedule_max_time`: Ignore event changes that are later than this for Quest reschedules
+- `reschedule_check_timeframe`: Defines the hours in which the plugin checks for quest reschedules
+- `reschedule_for`: Define event types, which triggers quest reschedules for their start, end or both.
   - `event community-day` - if you want to rescan quests for every start and end of an event and cday
   - `event:start` - only rescan quests for event starts (my personal recommendation)
   - `community-day event:end` - Rescan quests for cday starts and ends, but only for event ends
   - Available event types are `event`, `community-day`, `spotlight-hour` and `raid-hour`. The last 2 are less relevant. Most events are of type `event`.
 
+### Config options (plugin.ini) - Quest reset
+- `enable_reschedule`: Whether or not to enable auto Quest reset by SQL TRUNCATE trs_quest table of MAD database
+- `reset_for`: Define event types, which triggers quest resets for their start, end or both. see `reschedule_for` for details.
 
 ### walker_settings.txt
 ```
@@ -69,3 +76,6 @@ Wildcards can be used to further refine walkervalues. Their syntax work the same
 - `ifevent(X, Y)` uses X if there's an event and Y if there's not.
 
 Nested wildcards are supported. So you could use `max(12:00, add(5))` or `ifevent(min(max(03:00, ?), min(04:00, ?)), ?)`
+
+# Support / Contact
+Please join [this discord](https://discord.gg/cMZs5tk)

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ There are following config options:
 - `delete_events` if you want Event Watcher to delete non-needed events (including basically all you've created yourself) - by default it's set to False.
 - `max_event_duration` ignore events with duration longer than max_event_duration days. Set to 999 if you want to care also for session events
 - `reset_pokemons` option to automatically delete obsolete pokemon from MAD database on start and end of spawn event to enable MAD to rescan pokemon. true: enable function, false: disable function (default)
+- `reset_pokemons_truncate` option to use TRUNCATE SQL query instead of DELETE. Recommended for bigger instances. true: use TRUNCATE, false: use DELETE (default)
 
 please also join [this discord](https://discord.gg/cMZs5tk)
 

--- a/autoevents.py
+++ b/autoevents.py
@@ -149,11 +149,12 @@ class EventWatcher(mapadroid.utils.pluginBase.Plugin):
             sql_args = None
         else:
             sql_query = "DELETE FROM pokemon WHERE last_modified < %s AND disappear_time > %s"
+            datestring = eventchange_datetime_UTC.strftime("%Y-%m-%d %H:%M:%S")
             sql_args = (
-                eventchange_datetime_UTC,
-                eventchange_datetime_UTC
+                datestring,
+                datestring
             )
-        dbreturn = self._mad['db_wrapper'].execute(sql_query, sql_args)
+        dbreturn = self._mad['db_wrapper'].execute(sql_query, args=sql_args, commit=True)
         self._mad['logger'].info(f'Event Watcher: pokemon deleted by SQL query: {sql_query} arguments: {sql_args} return: {dbreturn}')
 
     def _check_pokemon_resets(self):

--- a/autoevents.py
+++ b/autoevents.py
@@ -87,24 +87,24 @@ class EventWatcher(mapadroid.utils.pluginBase.Plugin):
             self.__reset_pokemons_truncate = self._pluginconfig.getboolean("plugin", "reset_pokemons_truncate", fallback=False)
 
             if "Quest Resets" in self._pluginconfig.sections():
-                # handle quest reschedule parameter
-                self.__quests_reschedule_enable = self._pluginconfig.getboolean("Quest Resets", "enable_reschedule", fallback=False)
-                self.__quests_reschedule_default_time = self._pluginconfig.get("Quest Resets", "reschedule_default_time")
-                self.__quest_reschedule_timeframe = self._pluginconfig.get("Quest Resets", "reschedule_check_timeframe", fallback=False)
-                if self.__quest_reschedule_timeframe:
-                    self.__quest_reschedule_timeframe = list(map(int, self.__quest_reschedule_timeframe.split("-")))
-                max_time = self._pluginconfig.get("Quest Resets", "reschedule_max_time").split(":")
-                self.__quests_reschedule_max_hour = int(max_time[0])
-                self.__quests_reschedule_max_minute = int(max_time[1])
-                reschedule_for = self._pluginconfig.get("Quest Resets", "reschedule_for", fallback="event")
-                self.__quests_reschedule_types = self._get_eventchanges_from_parameter(reschedule_for)
                 # handle quest reset parameter
-                self.__quests_reset_enable = self._pluginconfig.getboolean("Quest Resets", "enable_reset", fallback=False)
+                self.__quests_reset_enable = self._pluginconfig.getboolean("Quest Resets", "enable", fallback=False)
+                self.__quests_default_time = self._pluginconfig.get("Quest Resets", "default_time")
+                self.__quest_timeframe = self._pluginconfig.get("Quest Resets", "check_timeframe", fallback=False)
+                if self.__quest_timeframe:
+                    self.__quest_timeframe = list(map(int, self.__quest_timeframe.split("-")))
+                max_time = self._pluginconfig.get("Quest Resets", "max_time").split(":")
+                self.__quests_max_hour = int(max_time[0])
+                self.__quests_max_minute = int(max_time[1])
                 reset_for = self._pluginconfig.get("Quest Resets", "reset_for", fallback="event")
                 self.__quests_reset_types = self._get_eventchanges_from_parameter(reset_for)
+                # handle quest delete parameter
+                self.__quests_delete_enable = self._pluginconfig.getboolean("Quest Resets", "enable_quest_delete", fallback=False)
+                delete_quests_for = self._pluginconfig.get("Quest Resets", "delete_quests_for", fallback="event")
+                self.__quests_delete_etypes = self._get_eventchanges_from_parameter(delete_quests_for)
             else:
-                self.__quests_reschedule_enable = False
                 self.__quests_reset_enable = False
+                self.__quests_delete_enable = False
 
             try:
                 with open(self._rootdir + "/walker_settings.txt", "r", encoding="utf8") as f:
@@ -179,37 +179,37 @@ class EventWatcher(mapadroid.utils.pluginBase.Plugin):
                 break
         self._last_pokemon_reset_check = now;
 
-    def _reset_all_quests(self):
+    def _delete_all_quests(self):
         sql_query = "TRUNCATE trs_quest"
         dbreturn = self._mad['db_wrapper'].execute(sql_query, commit=True)
         self._mad['logger'].info(f'Event Watcher: Quests deleted by SQL query: {sql_query} return: {dbreturn}') 
 
-    def _check_quest_resets(self):
+    def _check_quest_delete(self):
         #get current time to check for event start and event end
         now = datetime.now()
         self._mad['logger'].info("Event Watcher: Check Quest reset")
         # check, if one of the pokemon event is just started or ended
         for event in self._quest_events:
             timetype = event["time_type"]
-            if timetype not in self.__quests_reset_types.get(event["type"], []):
+            if timetype not in self.__quests_delete_etypes.get(event["type"], []):
                 continue
             eventtime = event["time"]
             # event starts during last check?
             if self._last_quest_reset_check < eventtime <= now:
                 self._mad['logger'].success(f'Event Watcher: Reset Quests (event start/end detected for event type: {event["type"]})')
                 # remove all quests from MAD DB
-                self._reset_all_quests()
+                self._delete_all_quests()
                 self._mad["mapping_manager"].update()
                 break
         self._last_quest_reset_check = now
 
-    def _check_quest_reschedule(self):
+    def _check_quest_resets(self):
         now = datetime.now()
 
-        if self.__quest_reschedule_timeframe and not self.__quest_reschedule_timeframe[0] <= now.hour < self.__quest_reschedule_timeframe[1]:
+        if self.__quest_timeframe and not self.__quest_timeframe[0] <= now.hour < self.__quest_timeframe[1]:
             return
 
-        if now.hour > self.__quests_reschedule_max_hour - 3 and now.hour < self.__quests_reschedule_max_hour + 3:
+        if now.hour > self.__quests_max_hour - 3 and now.hour < self.__quests_max_hour + 3:
             return
 
         def to_timestring(time):
@@ -219,13 +219,13 @@ class EventWatcher(mapadroid.utils.pluginBase.Plugin):
 
         for event in self._quest_events:
             timetype = event["time_type"]
-            if timetype not in self.__quests_reschedule_types.get(event["type"], []):
+            if timetype not in self.__quests_reset_types.get(event["type"], []):
                 continue
 
             time = event["time"]
             if time < now:
                 continue
-            if time.hour > self.__quests_reschedule_max_hour and time.minute >= self.__quests_reschedule_max_minute:
+            if time.hour > self.__quests_max_hour and time.minute >= self.__quests_max_minute:
                 continue
 
             if time < smallest_time:
@@ -234,22 +234,22 @@ class EventWatcher(mapadroid.utils.pluginBase.Plugin):
         smallest_date = smallest_time.date()
         today = datetime.today()
         if smallest_time.year == 2100:
-            final_time = self.__quests_reschedule_default_time
+            final_time = self.__quests_default_time
         else:
             if (
                     (
                         smallest_date == (today + timedelta(days=1)).date()
-                        and now.hour > self.__quests_reschedule_max_hour
+                        and now.hour > self.__quests_max_hour
                     )
                     or
                     (
                         smallest_date == today.date()
-                        and now.hour <= self.__quests_reschedule_max_hour
+                        and now.hour <= self.__quests_max_hour
                     )
              ):
                 final_time = to_timestring(smallest_time)
             else:
-                final_time = self.__quests_reschedule_default_time
+                final_time = self.__quests_default_time
 
         if final_time is None:
             return
@@ -304,7 +304,7 @@ class EventWatcher(mapadroid.utils.pluginBase.Plugin):
                 return max(options)
 
             def wildcard_ifevent(options):
-                if final_time == self.__quests_reschedule_default_time:
+                if final_time == self.__quests_default_time:
                     return options[1]
                 else:
                     return options[0]
@@ -478,12 +478,12 @@ class EventWatcher(mapadroid.utils.pluginBase.Plugin):
                 except Exception as e:
                     self._mad['logger'].error(f"Event Watcher: Error while getting events: {e}")
 
-                if self.__quests_reschedule_enable and len(self._quest_events) > 0:
-                    self._mad['logger'].info("Event Watcher: Check Quest reschedule")
+                if self.__quests_reset_enable and len(self._quest_events) > 0:
+                    self._mad['logger'].info("Event Watcher: Check Quest reset")
                     try:
-                        self._check_quest_reschedule()
+                        self._check_quest_resets()
                     except Exception as e:
-                        self._mad['logger'].error(f"Event Watcher: Error while checking Quest reschedule")
+                        self._mad['logger'].error(f"Event Watcher: Error while checking Quest reset")
                         self._mad['logger'].exception(e)
 
                 if len(self._spawn_events) > 0:
@@ -500,15 +500,15 @@ class EventWatcher(mapadroid.utils.pluginBase.Plugin):
                 try:
                     self._check_pokemon_resets()
                 except Exception as e:
-                    self._mad['logger'].error(f"Event Watcher: Error while checking Pokemon Resets")
+                    self._mad['logger'].error(f"Event Watcher: Error while checking Pokemon reset")
                     self._mad['logger'].exception(e)
 
-            #if enabled, run quest reset check every cycle to ensure quest rescan just after quest related event change
-            if self.__quests_reset_enable:
+            #if enabled, run quest delete check every cycle to enable MAD to rescan quests just after quest related event change
+            if self.__quests_delete_enable:
                 try:
-                    self._check_quest_resets()
+                    self._check_quest_delete()
                 except Exception as e:
-                    self._mad['logger'].error(f"Event Watcher: Error while checking Quest Resets")
+                    self._mad['logger'].error(f"Event Watcher: Error while checking Quest delete")
                     self._mad['logger'].exception(e)
 
             time.sleep(self.__sleep_mainloop_in_s)

--- a/plugin.ini.example
+++ b/plugin.ini.example
@@ -1,9 +1,18 @@
 [plugin]
+; general plugin activation option ['true´ or 'false']
 active = true
+
+; define the time to wait in-between checking for new events in seconds. default = 3600 (= 1 hour)
 sleep = 3600
+
+; option to delete events from MAD database, which are not part of EventWatcher plugin ['true´ or 'false']
 delete_events = false
-; ignore events with duration longer than max_event_duration days
+
+; ignore events with duration longer than max_event_duration days. default = 999 (disable)
 max_event_duration = 30
+
+; option to automatically delete obsolete pokemon from MAD database on start and end of spawn event to enable MAD to rescan pokemon. ['true´ or 'false']
+reset_pokemons = false
 
 [Quest Resets]
 enable = true

--- a/plugin.ini.example
+++ b/plugin.ini.example
@@ -18,8 +18,18 @@ reset_pokemons = false
 reset_pokemons_truncate = false
 
 [Quest Resets]
-enable = true
-default_time = 02:00
-max_time = 12:00
-check_timeframe = 18-23
+; option to enable quest scan reschedule on upcoming quest related event change ['true' or 'false']
+enable_reschedule = true
+; default time for quest scan
+reschedule_default_time = 02:00
+; reschedule option: latest time for event changes to be considered for quest reschedule
+reschedule_max_time = 12:00
+; reschedule option: defines the timewindow hours in which the plugin checks for quest reschedule 
+reschedule_check_timeframe = 18-23
+; reschedule option: define event types, which shall be considered for quest reschedule. Separate different eventtypes with whitespace. <eventtype>:'start', 'end' or ''(=both)
+reschedule_for = event:start community-day
+
+; option to enable quest reset, which drop MAD table trs_quest on quest related event change ['true' or 'false']
+enable_reset = false
+; reschedule option: define event types, which shall be considered for quest reschedule. Separate different eventtypes with whitespace. <eventtype>:'start', 'end' or ''(=both)
 reset_for = event:start community-day

--- a/plugin.ini.example
+++ b/plugin.ini.example
@@ -18,18 +18,18 @@ reset_pokemons = false
 reset_pokemons_truncate = false
 
 [Quest Resets]
-; option to enable quest scan reschedule on upcoming quest related event change ['true' or 'false']
-enable_reschedule = true
-; default time for quest scan
-reschedule_default_time = 02:00
-; reschedule option: latest time for event changes to be considered for quest reschedule
-reschedule_max_time = 12:00
-; reschedule option: defines the timewindow hours in which the plugin checks for quest reschedule 
-reschedule_check_timeframe = 18-23
-; reschedule option: define event types, which shall be considered for quest reschedule. Separate different eventtypes with whitespace. <eventtype>:'start', 'end' or ''(=both)
-reschedule_for = event:start community-day
-
-; option to enable quest reset, which drop MAD table trs_quest on quest related event change ['true' or 'false']
-enable_reset = false
-; reschedule option: define event types, which shall be considered for quest reschedule. Separate different eventtypes with whitespace. <eventtype>:'start', 'end' or ''(=both)
+; option to enable quest reset (scan reschedule) on upcoming quest related event change ['true' or 'false']
+enable = true
+; quest reset option: default time for quest scan
+default_time = 02:00
+; quest reset option: latest time for event changes to be considered for quest reset
+max_time = 12:00
+; quest reset option: defines the timewindow hours in which the plugin checks for quest reset
+check_timeframe = 18-23
+; quest reset option: define event types, which shall be considered for quest reset. Separate different eventtypes with whitespace. <eventtype>:'start', 'end' or ''(=both)
 reset_for = event:start community-day
+
+; option to enable quest delete, which drop MAD table trs_quest on quest related event change ['true' or 'false']
+enable_quest_delete = false
+; quest delete option: define event types, which shall be considered for quest reschedule. Separate different eventtypes with whitespace. <eventtype>:'start', 'end' or ''(=both)
+delete_quests_for = event:start community-day

--- a/plugin.ini.example
+++ b/plugin.ini.example
@@ -1,20 +1,20 @@
 [plugin]
-; general plugin activation option ['true´ or 'false']
+; general plugin activation option ['true' or 'false']
 active = true
 
 ; define the time to wait in-between checking for new events in seconds. default = 3600 (= 1 hour)
 sleep = 3600
 
-; option to delete events from MAD database, which are not part of EventWatcher plugin ['true´ or 'false']
+; option to delete events from MAD database, which are not part of EventWatcher plugin ['true' or 'false']
 delete_events = false
 
 ; ignore events with duration longer than max_event_duration days. default = 999 (disable)
 max_event_duration = 30
 
-; option to automatically delete obsolete pokemon from MAD database on start and end of spawn event to enable MAD to rescan pokemon. ['true´ or 'false']
+; option to automatically delete obsolete pokemon from MAD database on start and end of spawn event to enable MAD to rescan pokemon. ['true' or 'false']
 reset_pokemons = false
 
-; option to use TRUNCATE SQL query instead of DELETE. Recommended for bigger instances ['true´ or 'false']
+; option to use TRUNCATE SQL query instead of DELETE. Recommended for bigger instances ['true' or 'false']
 reset_pokemons_truncate = false
 
 [Quest Resets]

--- a/plugin.ini.example
+++ b/plugin.ini.example
@@ -14,6 +14,9 @@ max_event_duration = 30
 ; option to automatically delete obsolete pokemon from MAD database on start and end of spawn event to enable MAD to rescan pokemon. ['true´ or 'false']
 reset_pokemons = false
 
+; option to use TRUNCATE SQL query instead of DELETE. Recommended for bigger instances ['true´ or 'false']
+reset_pokemons_truncate = false
+
 [Quest Resets]
 enable = true
 default_time = 02:00


### PR DESCRIPTION
# Feature description
1. **Pokemon reset**: MAD don't update pokemon in DB, if pokemon change because of a event start or event end. So this new feature check for events with different pokemon pool. If a relevant event change is detected, pokemon, which are scanned before event change (last_modified) and despawn after event change (disappear_time), will be removed from MAD DB. So MAD will rescan them.
2. **Quest delete**: add quest delete feature, which delete quests from MAD DB on quest related event change.

new plugin.ini parameter - general:
- `reset_pokemons`: set to `true`, to enable feature
- `reset_pokemons_truncate`:  set to `true`, to use SQL TRUNCATE to delete all pokemon DB entries on event change. Recommended for big MAD instances with huge DBs and many devices. Set to `false`, to use SQL DELETE to delete only the event change effected pokemon DB entries.

new plugin.ini parameter - Quest resets:
- `enable_quest_delete`: Whether or not to enable auto Quest delete by SQL TRUNCATE trs_quest table of MAD database
- `delete_quests_for`: Define event types, which triggers quest delete for their start, end or both. see `reschedule_for` for details.

**Remark: not well tested, because of missing event change :-/ Please review and test. I do welcome all kinds of feedback.**
@crhbetz please don't merge until positive feedback

# Change details
1. I split the plugin loop into a fast one (60 s loop) to check for event change and a slow one (include all old functions) by adding a counter
2. I added a _pokemon_events list for pokemon relevant events (Type: community-day, spotlight-hour or entries in spawns)
3. I added a cooldown function for pokemon resets with fix 30 minutes, to limit SQL DELETE request to one per event change
4. Convert event times to UTC time (pokemon table use UTC) by subtract self.tz_offset
5. SQL delete request: `DELETE FROM pokemon WHERE last_modified < *datetime event start/end in UTC* AND disappear_time > *datetime event start/end in UTC*` or `TRUNCATE pokemon`

