### PR TITLE
Fix: use default 3 hours for bonus lure duration, if value is missing

### DIFF
--- a/autoevents.py
+++ b/autoevents.py
@@ -380,7 +380,9 @@ class EventWatcher(mapadroid.utils.pluginBase.Plugin):
 
             for bonus in raw_event["bonuses"]:
                 if bonus.get("template", "") == "longer-lure":
-                    event_dict["lure"] = bonus["value"]*60
+                    # get bonus duration time in hour. If not available use default=3
+                    bonus_lure_duration_hours = bonus.get("value", 3)
+                    event_dict["lure"] = bonus_lure_duration_hours*60
                     break
             if raw_event["has_spawnpoints"] or event_dict.get("lure"):
                 self._spawn_events.append(event_dict)

--- a/autoevents.py
+++ b/autoevents.py
@@ -380,10 +380,10 @@ class EventWatcher(mapadroid.utils.pluginBase.Plugin):
 
             for bonus in raw_event["bonuses"]:
                 if bonus.get("template", "") == "longer-lure":
-                    # get bonus duration time in hour. If not available use default=3
-                    bonus_lure_duration_hours = bonus.get("value", 3)
-                    event_dict["lure"] = bonus_lure_duration_hours*60
-                    break
+                    bonus_lure_duration_hours = bonus.get("value")
+                    if bonus_lure_duration_hours is not None:
+                        event_dict["lure"] = bonus_lure_duration_hours*60
+                        break
             if raw_event["has_spawnpoints"] or event_dict.get("lure"):
                 self._spawn_events.append(event_dict)
             if raw_event["has_quests"]:


### PR DESCRIPTION
If "value" in "longer-lure" is missing in event.json from pogoinfo (can happen if provided data from external changes or data is not ) the script will fail because of missing dict entry.
So use .get() fucntion instead with default value 3. Will result in 180 minute lure duration time as default value.